### PR TITLE
Basic app definitions for Trino and the Hive Metastore deployment

### DIFF
--- a/charts/teleport/templates/application/app-hive.yaml
+++ b/charts/teleport/templates/application/app-hive.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.appTrino.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app-jupyter
+  namespace: {{ .Values.global.application.argocd.namespace }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  destination:
+    namespace: "{{ .Values.global.namespacePrefix }}-{{ .Values.appTrino.namespace }}"
+    server: {{ .Values.global.application.address }}
+  project: {{ .Values.global.application.argocd.project }}
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:  
+    - CreateNamespace=true
+  source:
+    {{- .Values.appTrino.source | toYaml | nindent 4 }}
+    helm:
+      valueFiles:
+        - values.yaml
+      {{- if .Values.appTrino.values }}
+      values: |
+        {{- .Values.appTrino.values | toYaml | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/teleport/templates/application/app-trino.yaml
+++ b/charts/teleport/templates/application/app-trino.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.appTrino.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app-jupyter
+  namespace: {{ .Values.global.application.argocd.namespace }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  destination:
+    namespace: "{{ .Values.global.namespacePrefix }}-{{ .Values.appTrino.namespace }}"
+    server: {{ .Values.global.application.address }}
+  project: {{ .Values.global.application.argocd.project }}
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:  
+    - CreateNamespace=true
+  source:
+    {{- .Values.appTrino.source | toYaml | nindent 4 }}
+    helm:
+      valueFiles:
+        - values.yaml
+      {{- if .Values.appTrino.values }}
+      values: |
+        {{- .Values.appTrino.values | toYaml | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/teleport/values.yaml
+++ b/charts/teleport/values.yaml
@@ -35,6 +35,24 @@ appJupyter:
     # renovate: datasource=helm depName=jupyter registryUrl=https://harbor.ukserp.ac.uk/chartrepo/dare
     targetRevision: 1.0.0
 
+appTrino:
+  enabled: true
+  namespace: trino
+  source:
+    repoURL: https://harbor.ukserp.ac.uk/chartrepo/dare
+    chart: trino
+    # renovate: datasource=helm depName=trino registryUrl=https://harbor.ukserp.ac.uk/chartrepo/dare
+    targetRevision: 1.0.1
+
+appHive:
+  enabled: true
+  namespace: hive
+  source:
+    repoURL: https://harbor.ukserp.ac.uk/chartrepo/dare
+    chart: hive
+    # renovate: datasource=helm depName=hive registryUrl=https://harbor.ukserp.ac.uk/chartrepo/dare
+    targetRevision: 1.0.0
+
 appVault:
   enabled: true
   namespace: vault


### PR DESCRIPTION
Notes: 
- Hive MS must _always_ be deployed alongside Trino -- it's not optional and cannot be overridden/is not a deployment choice.
- Both sources are currently our internal charts; this will change to DARE-specific charts when those repos are set up