### PR TITLE
feat: individual components can now override their cluster group

### DIFF
--- a/charts/teleport/templates/application/app-guacamole.yaml
+++ b/charts/teleport/templates/application/app-guacamole.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   destination:
     namespace: "{{ .Values.global.namespacePrefix }}-{{ .Values.appGuacamole.namespace }}"
-    server: {{ eq .Values.appGuacamole.cluster_override "" | ternary .Values.global.application.address .Values.appGuacamole.cluster_override }}
+    server: {{ eq .Values.appGuacamole.cluster "" | ternary .Values.global.application.address .Values.appGuacamole.cluster }}
   project: {{ .Values.global.application.argocd.project }}
   syncPolicy:
     automated:

--- a/charts/teleport/templates/application/app-hive.yaml
+++ b/charts/teleport/templates/application/app-hive.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   destination:
     namespace: "{{ .Values.global.namespacePrefix }}-{{ .Values.appHive.namespace }}"
-    server: {{ eq .Values.appHive.cluster_override "" | ternary .Values.global.application.address .Values.appHive.cluster_override }}
+    server: {{ eq .Values.appHive.cluster "" | ternary .Values.global.application.address .Values.appHive.cluster }}
   project: {{ .Values.global.application.argocd.project }}
   syncPolicy:
     automated:

--- a/charts/teleport/templates/application/app-jupyter.yaml
+++ b/charts/teleport/templates/application/app-jupyter.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   destination:
     namespace: "{{ .Values.global.namespacePrefix }}-{{ .Values.appJupyter.namespace }}"
-    server: {{ eq .Values.appJupyter.cluster_override "" | ternary .Values.global.application.address .Values.appJupyter.cluster_override }}
+    server: {{ eq .Values.appJupyter.cluster "" | ternary .Values.global.application.address .Values.appJupyter.cluster }}
   project: {{ .Values.global.application.argocd.project }}
   syncPolicy:
     automated:

--- a/charts/teleport/templates/application/app-trino.yaml
+++ b/charts/teleport/templates/application/app-trino.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   destination:
     namespace: "{{ .Values.global.namespacePrefix }}-{{ .Values.appTrino.namespace }}"
-    server: {{ eq .Values.appTrino.cluster_override "" | ternary .Values.global.application.address .Values.appTrino.cluster_override }}
+    server: {{ eq .Values.appTrino.cluster "" | ternary .Values.global.application.address .Values.appTrino.cluster }}
   project: {{ .Values.global.application.argocd.project }}
   syncPolicy:
     automated:

--- a/charts/teleport/templates/management/app-control.yaml
+++ b/charts/teleport/templates/management/app-control.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   destination:
     namespace: "{{ .Values.global.namespacePrefix }}-{{ .Values.appControl.namespace }}"
-    server: {{ eq .Values.appControl.cluster_override "" | ternary .Values.global.management.address .Values.appControl.cluster_override }}
+    server: {{ eq .Values.appControl.cluster "" | ternary .Values.global.management.address .Values.appControl.cluster }}
   project: {{ .Values.global.management.argocd.project }}
   syncPolicy:
     automated:

--- a/charts/teleport/templates/management/app-opa.yaml
+++ b/charts/teleport/templates/management/app-opa.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   destination:
     namespace: "{{ .Values.global.namespacePrefix }}-{{ .Values.appOpa.namespace }}"
-    server: {{ eq .Values.appOpa.cluster_override "" | ternary .Values.global.management.address .Values.appOpa.cluster_override }}
+    server: {{ eq .Values.appOpa.cluster "" | ternary .Values.global.management.address .Values.appOpa.cluster }}
   project: {{ .Values.global.management.argocd.project }}
   syncPolicy:
     automated:

--- a/charts/teleport/templates/management/app-vault.yaml
+++ b/charts/teleport/templates/management/app-vault.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   destination:
     namespace: "{{ .Values.global.namespacePrefix }}-{{ .Values.appVault.namespace }}"
-    server: {{ eq .Values.appVault.cluster_override "" | ternary .Values.global.management.address .Values.appVault.cluster_override }}
+    server: {{ eq .Values.appVault.cluster "" | ternary .Values.global.management.address .Values.appVault.cluster }}
   project: {{ .Values.global.management.argocd.project }}
   syncPolicy:
     automated:

--- a/charts/teleport/templates/monitoring/app-loki.yaml
+++ b/charts/teleport/templates/monitoring/app-loki.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   destination:
     namespace: "{{ .Values.global.namespacePrefix }}-{{ .Values.appLoki.namespace }}"
-    server: {{ eq .Values.appLoki.cluster_override "" | ternary .Values.global.monitoring.address .Values.appLoki.cluster_override }}
+    server: {{ eq .Values.appLoki.cluster "" | ternary .Values.global.monitoring.address .Values.appLoki.cluster }}
   project: {{ .Values.global.monitoring.argocd.project }}
   syncPolicy:
     automated:

--- a/charts/teleport/templates/monitoring/app-prometheus-stack.yaml
+++ b/charts/teleport/templates/monitoring/app-prometheus-stack.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   destination:
     namespace: "{{ .Values.global.namespacePrefix }}-{{ .Values.appPromStack.namespace }}"
-    server: {{ eq .Values.appPromStack.cluster_override "" | ternary .Values.global.monitoring.address .Values.appPromStack.cluster_override }}
+    server: {{ eq .Values.appPromStack.cluster "" | ternary .Values.global.monitoring.address .Values.appPromStack.cluster }}
   project: {{ .Values.global.monitoring.argocd.project }}
   syncPolicy:
     automated:

--- a/charts/teleport/values.yaml
+++ b/charts/teleport/values.yaml
@@ -19,7 +19,7 @@ global:
 
 appGuacamole:
   enabled: true
-  cluster_override: ""
+  cluster: ""
   namespace: guacamole
   source:
     repoURL: https://harbor.ukserp.ac.uk/chartrepo/dare
@@ -29,7 +29,7 @@ appGuacamole:
 
 appJupyter:
   enabled: true
-  cluster_override: ""
+  cluster: ""
   namespace: jupyter
   source:
     repoURL: https://harbor.ukserp.ac.uk/chartrepo/dare
@@ -39,7 +39,7 @@ appJupyter:
 
 appTrino:
   enabled: true
-  cluster_override: ""
+  cluster: ""
   namespace: trino
   source:
     repoURL: https://harbor.ukserp.ac.uk/chartrepo/dare
@@ -49,7 +49,7 @@ appTrino:
 
 appHive:
   enabled: true
-  cluster_override: ""
+  cluster: ""
   namespace: hive
   source:
     repoURL: https://harbor.ukserp.ac.uk/chartrepo/dare
@@ -59,7 +59,7 @@ appHive:
 
 appVault:
   enabled: true
-  cluster_override: ""
+  cluster: ""
   namespace: vault
   source:
     repoURL: https://helm.releases.hashicorp.com
@@ -69,7 +69,7 @@ appVault:
 
 appOpa:
   enabled: true
-  cluster_override: ""
+  cluster: ""
   namespace: opa
   source:
     repoURL: https://harbor.ukserp.ac.uk/chartrepo/dare
@@ -79,7 +79,7 @@ appOpa:
 
 appControl:
   enabled: true
-  cluster_override: ""
+  cluster: ""
   namespace: control
   source:
     repoURL: https://harbor.ukserp.ac.uk/chartrepo/dare
@@ -89,7 +89,7 @@ appControl:
 
 appPromStack:
   enabled: true
-  cluster_override: ""
+  cluster: ""
   namespace: monitoring
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
@@ -99,7 +99,7 @@ appPromStack:
 
 appLoki:
   enabled: true
-  cluster_override: ""
+  cluster: ""
   namespace: monitoring
   source:
     repoURL: https://grafana.github.io/helm-charts


### PR DESCRIPTION
It allows the user to tailor component deployment locations and means they're not tied into our strict 3-cluster model.

This should close #36 